### PR TITLE
Feat: 영수증 조회, 작성 페이지네이션 구현

### DIFF
--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+const Pagination = ({ currentPage, totalPages, onPageChange }) => {
+  const pageNumbers = [];
+  const maxPageButtons = 5; // 한 번에 보여줄 페이지 버튼의 최대 개수
+
+  let startPage = Math.max(1, currentPage - Math.floor(maxPageButtons / 2));
+  let endPage = Math.min(totalPages, startPage + maxPageButtons - 1);
+
+  if (endPage - startPage + 1 < maxPageButtons) {
+    startPage = Math.max(1, endPage - maxPageButtons + 1);
+  }
+
+  for (let i = startPage; i <= endPage; i++) {
+    pageNumbers.push(i);
+  }
+
+  return (
+    <div className="flex items-center justify-center mt-4 mb-4 space-x-2">
+      <button
+        onClick={() => onPageChange(1)}
+        disabled={currentPage === 1}
+        className={`px-3 py-1 rounded ${
+          currentPage === 1 ? 'text-gray-400 cursor-not-allowed' : 'text-[#002D72] hover:text-[#CED3FF]'
+        }`}
+      >
+        {'<<'}
+      </button>
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        className={`px-3 py-1 rounded ${
+          currentPage === 1 ? 'text-gray-400 cursor-not-allowed' : 'text-[#002D72] hover:text-[#CED3FF]'
+        }`}
+      >
+        {'<'}
+      </button>
+      {pageNumbers.map((number) => (
+        <button
+          key={number}
+          onClick={() => onPageChange(number)}
+          className={`px-3 py-1 rounded ${
+            currentPage === number ? 'bg-[#CED3FF] text-[#002D72]' : 'text-[#002D72] hover:text-[#CED3FF]'
+          }`}
+        >
+          {number}
+        </button>
+      ))}
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        className={`px-3 py-1 rounded ${
+          currentPage === totalPages ? 'text-gray-400 cursor-not-allowed' : 'text-[#002D72] hover:text-[#CED3FF]'
+        }`}
+      >
+        {'>'}
+      </button>
+      <button
+        onClick={() => onPageChange(totalPages)}
+        disabled={currentPage === totalPages}
+        className={`px-3 py-1 rounded ${
+          currentPage === totalPages ? 'text-gray-400 cursor-not-allowed' : 'text-[#002D72] hover:text-[#CED3FF]'
+        }`}
+      >
+        {'>>'}
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #80

### 📝작업 내용

> 영수증 조회, 작성 페이지네이션 구현
- 영수증 개수가 증가하면 페이지 스크롤뷰가 그만큼 증가하는 문제 발생
- 페이지네이션 컴포넌트 생성
- 페이지 이동을 위한 버튼이 있어서 각 페이지에 10개의 항목만 표시

### 🔨테스트 결과 > 스크린샷 (선택)

![스크린샷 2025-03-09 오후 5 07 44(2)](https://github.com/user-attachments/assets/fe6d3a3b-9c62-4f22-862a-9cf19d7cd3d3)

